### PR TITLE
correct diff_smt_loca determination

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1189,10 +1189,10 @@ def allPositionsInOneFile(ofile='result.xls',controlPositionFile=None,treatPosit
                 tp=div((minp+maxp),(2*step))
                 tdis=div((maxp-minp),(2*step))
                 while tdis>=0:
-                    if abs(maxv)>abs(dwig.data[cr][int(tp+tdis)]):
+                    if abs(maxv)<abs(dwig.data[cr][int(tp+tdis)]):
                         maxv=dwig.data[cr][tp+tdis]
                         p=tp+tdis
-                    if abs(maxv)>abs(dwig.data[cr][int(tp-tdis)]):
+                    if abs(maxv)<abs(dwig.data[cr][int(tp-tdis)]):
                         maxv=dwig.data[cr][tp-tdis]
                         p=tp-tdis
                     tdis-=1


### PR DESCRIPTION
This commit fixes a bug which led to DANPOS detecting wrong `diff_smt_loca` values. 

This affected the values of `control_point_val`, `treat_point_val`, `point_log2FC`, `point_diff_log10Pval` and `point_diff_FDR` in the `*.positions.integrative.xls` output when comparing two samples.